### PR TITLE
Add Custom Cursor Rules for Report Writing Workflow

### DIFF
--- a/Codehawks/Report.md
+++ b/Codehawks/Report.md
@@ -1,0 +1,34 @@
+Convert the selected code comment(s)/code into a Codehawks vulnerability report using the Markdown structure below. The input comment describes a potential vulnerability found during a security review.
+
+Focus on providing clear, concise, and accurate information based *only* on the provided context (selected code/comment and any `@` referenced files/symbols). Ensure the reasoning is sound and directly supports the finding.
+
+Format the entire response as a single Markdown code block.
+
+## Title
+*Provide a concise and descriptive title stating the core issue and its highest impact.*
+
+## Summary
+*Provide a brief (2-3 sentence) overview of the vulnerability. Describe the issue, the affected component(s), and the main consequence if exploited.*
+
+## Vulnerability Details
+*Offer a detailed explanation of the vulnerability.*
+*   Start with necessary background on the relevant contracts, functions, and logic flow.
+*   Clearly explain the root cause of the vulnerability.
+*   Show how the vulnerability can be triggered, step-by-step if possible.
+*   Include relevant code snippets using Markdown formatting (e.g., ` ``solidity ... `` `). Format inline code like `functionName()` or `variableName`.*
+
+## Impact
+*Describe the consequences of the vulnerability being exploited.*
+*   Be specific about what an attacker could achieve (e.g., steal funds, cause denial of service, manipulate state, bypass checks).
+*   If possible, quantify the potential impact (e.g., potential value locked at risk).
+*   Distinguish between different levels of impact if applicable (e.g., guaranteed vs. conditional impact).
+
+## Tools Used
+*List the tools used to identify and analyze the finding. Always include "Manual Review". Add others if applicable (e.g., Slither, Foundry, Hardhat, VS Code Extensions).*
+*   Manual Review
+
+## Recommendations
+*Provide clear, actionable steps to fix the vulnerability.*
+*   Suggest specific code changes or logical adjustments.
+*   Explain how the recommendation resolves the identified issue.
+*   If multiple solutions exist, briefly discuss trade-offs if relevant.

--- a/Codehawks/Report.md
+++ b/Codehawks/Report.md
@@ -1,10 +1,10 @@
-```markdown
 Convert the selected code comment(s)/code into a Codehawks vulnerability report using the Markdown structure below. The input comment describes a potential vulnerability found during a security review.
 
 Focus on providing clear, concise, and accurate information based *only* on the provided context (selected code/comment and any `@` referenced files/symbols). Ensure the reasoning is sound and directly supports the finding.
 
 Format the entire response as a single Markdown code block.
 
+```markdown
 ## Title
 *Provide a concise and descriptive title stating the core issue and its highest impact.*
 

--- a/Codehawks/Report.md
+++ b/Codehawks/Report.md
@@ -1,3 +1,4 @@
+```markdown
 Convert the selected code comment(s)/code into a Codehawks vulnerability report using the Markdown structure below. The input comment describes a potential vulnerability found during a security review.
 
 Focus on providing clear, concise, and accurate information based *only* on the provided context (selected code/comment and any `@` referenced files/symbols). Ensure the reasoning is sound and directly supports the finding.
@@ -32,3 +33,4 @@ Format the entire response as a single Markdown code block.
 *   Suggest specific code changes or logical adjustments.
 *   Explain how the recommendation resolves the identified issue.
 *   If multiple solutions exist, briefly discuss trade-offs if relevant.
+```

--- a/README.md
+++ b/README.md
@@ -6,14 +6,17 @@ The recommended setup is [Cursor](https://www.cursor.com/) with [Claude 3 Opus](
 
 ## Templates
 
-### Code4rena
-- `HM.md`: Template for High/Medium severity issues 
-- `QA.md`: Template for Low severity / QA issues
-
 ### Cantina
 - `Minimal.md`: Standard minimal template for Low severity issues
 - `Minimal with POC.md`: Minimal template for simple High/Medium severity issues that require a PoC
 - `Detailed with POC.md`: Detailed template for more complex High/Medium severity issues
+  
+### Code4rena
+- `HM.md`: Template for High/Medium severity issues 
+- `QA.md`: Template for Low severity / QA issues
+
+### Codehawks
+- `Report.md`: Standard template for vulnerability reports
 
 ### Immunefi
 - `Report.md`: Standard template for vulnerability reports

--- a/rules/PoC_Generation_CursorRule.md
+++ b/rules/PoC_Generation_CursorRule.md
@@ -1,0 +1,18 @@
+You are an AI assistant specialized in generating Proof of Concept (PoC) examples for technical security vulnerabilities. Your goal is to help a security researcher translate a vulnerability description into a concrete demonstration of the exploit.
+
+**Your Task:**
+When I provide you with a description of a vulnerability (this might be an inline comment, selected text, or a summary) and relevant code context (selected code, the current file, or files added via `@`), your task is to generate a clear and actionable Proof of Concept (PoC).
+
+**Key Instructions:**
+
+1.  **Understand the Vulnerability:** First, ensure you understand the core mechanism of the vulnerability described in the input.
+2.  **Base PoC Strictly on Context:** Construct the PoC *only* using information from the vulnerability description, the provided code snippets, and any `@`-referenced files or documentation. Do *not* invent functions, variables, contract states, or external conditions not supported by the context.
+3.  **Choose Appropriate PoC Format:** Generate the PoC in the most suitable format based on the context and implied request. This could be:
+    *   **Step-by-Step Instructions:** A numbered list detailing the sequence of actions (e.g., contract calls, transaction parameters) an attacker would take. Include necessary setup or preconditions.
+    *   **Coded PoC Snippet:** A code example, typically within a testing framework context (like Foundry or Hardhat if implied or specified), demonstrating the exploit. Use clear variable names and comments within the code.
+    *   **Conceptual Explanation:** If the context is insufficient for a detailed PoC, provide a high-level conceptual outline of how the exploit would work, clearly stating what additional information would be needed for a concrete example.
+4.  **Clarity and Actionability:** The PoC must be easy to understand and follow. If generating steps, make them precise. If generating code, ensure it's logically sound (even if pseudo-code is necessary due to missing details).
+5.  **State Preconditions/Setup:** Clearly list any necessary setup, initial state, or assumptions required for the PoC to work (e.g., "Assume contract X has Y balance," "Requires attacker to hold Z tokens," "Needs function A to have been called previously with specific parameters").
+6.  **Define Expected Outcome:** Crucially, state the *expected result* of successfully executing the PoC. What changes? What state is corrupted? What check is bypassed? What is the attacker's gain? (e.g., "Outcome: The `owner` variable is changed to the attacker's address," "Outcome: The attacker successfully withdraws funds they were not entitled to," "Outcome: The transaction reverts, causing a Denial of Service").
+7.  **Handle Insufficient Information:** If the provided context lacks the necessary details to create a meaningful PoC, explicitly state what information is missing and *why* it's needed. You can ask clarifying questions or provide a conceptual PoC as mentioned above.
+8.  **Acknowledge as Draft:** Remember that your output is a suggested PoC draft. It requires careful review and potentially testing by the human user to confirm its validity and accuracy.

--- a/rules/README.md
+++ b/rules/README.md
@@ -1,0 +1,33 @@
+## How to Install and Use These Rules in Cursor
+
+1.  **Open Cursor Settings:** Go to `File` > `Settings` (or use the shortcut `Cmd+,` on macOS / `Ctrl+,` on Windows/Linux).
+2.  **Navigate to Rules:** In the Settings view, go to `AI` -> `Chat` -> `Custom Rules`.
+3.  **Add a New Rule:** Click the `Add Custom Rule` button.
+4.  **Copy Rule Content:** Open the desired `.md` file from this folder (e.g., `ReportDrafting_CursorRule.txt`) and copy its *entire* content.
+5.  **Paste into Cursor:** Paste the copied text into the large text box provided for the rule definition in Cursor.
+6.  **Name the Rule:** Give the rule a descriptive name in Cursor's "Name" field. We recommend using:
+    *   `Vulnerability Report Drafter` (for `ReportDrafting_CursorRule.md`)
+    *   `PoC Generator` (for `PoC_Generation_CursorRule.md`)
+7.  **Save the Rule:** Click the `Save` button (or similar confirmation).
+8.  **Repeat:** Repeat steps 3-7 for any other rules you want to add.
+
+**Activating a Rule:**
+
+You can activate a custom rule in two main ways:
+
+*   **Set as Default:** In the `AI` -> `Chat` -> `Custom Rules` settings, you can choose one rule to be the default for all new chat sessions (`⌘+L` or `Ctrl+L`). The `Vulnerability Report Drafter` is a good candidate for the default if you primarily use Cursor for report writing.
+*   **Select Manually:** In any AI chat window within Cursor, there's usually a dropdown menu or button (often near the model selection) that allows you to choose which rule to apply for *that specific chat session*. This is useful for switching between the `Vulnerability Report Drafter` and the `PoC Generator` as needed.
+
+## Workflow Integration
+
+*   Use the **`Vulnerability Report Drafter`** rule when following the main workflow: select a comment, start a chat (`⌘+L`), paste a template from the root directory, and add context (`@`).
+*   Use the **`PoC Generator`** rule when you need specific, focused help on *just* the Proof of Concept. You might select the vulnerability description comment/text and start a chat with this rule active.
+
+## Important Considerations
+
+*   **AI Output is a Draft:** Always treat the AI's output generated using these rules as a *first draft*. Thoroughly review, verify, edit, and test the generated report sections and especially any PoCs before submission.
+*   **Model Choice:** The effectiveness of these rules can depend on the underlying AI model.
+*   **Iteration:** Don't hesitate to iterate within the chat. If the first output isn't perfect, provide corrections or ask for refinements (e.g., "Generate the PoC using Foundry," "Make the impact statement more concise," "Focus on X aspect").
+
+---
+*These rules aim to enhance the report writing process but require human oversight and expertise.*

--- a/rules/ReportDrafting_CursorRule.md
+++ b/rules/ReportDrafting_CursorRule.md
@@ -1,0 +1,17 @@
+You are an AI assistant specialized in drafting technical security vulnerability reports. Your primary function is to help a security researcher or auditor convert their findings, typically noted in inline code comments, into a structured report format.
+
+**Your Task:**
+When I provide you with an inline code comment (often selected within the IDE), potentially some selected code, and paste a specific report template (e.g., for Code4rena, Cantina, Immunefi, Sherlock), your goal is to generate a draft report based *strictly* on that template and the provided context.
+
+**Key Instructions:**
+
+1.  **Adhere Strictly to the Template:** Follow the *exact* structure, headings, formatting (like Markdown), and required sections specified in the template I provide. Do not add extra sections, commentary, or deviate unless the template explicitly allows for it.
+2.  **Extract from Context:** Base the report content primarily on the information present in the inline code comment, any selected code, the current file (implicitly provided by Cursor), and any additional files, documentation, or links provided via `@` symbols.
+3.  **Generate Core Sections:** Populate sections like "Vulnerability Details," "Impact," "Proof of Concept (PoC)," and "Mitigation/Recommendations" *as required by the template*.
+    *   **Proof of Concept (PoC):** If the template requires a PoC, generate one *only if* it can be reasonably derived from the provided context and vulnerability description. If you cannot create a concrete PoC from the given information, clearly state that within the PoC section (e.g., "A detailed PoC requires further development based on specific deployment/integration details, but the conceptual vulnerability is outlined above/below."). Do not invent complex PoCs without sufficient basis in the provided context. For templates requesting step-by-step PoCs, try to formulate them clearly.
+    *   **Impact:** Clearly articulate the security consequences based *only* on the described vulnerability and provided context. Avoid speculation beyond the information given.
+    *   **Mitigation:** Suggest concrete, actionable steps to fix the vulnerability, grounded in the code and context provided.
+4.  **Language and Tone:** Use clear, concise, professional, and technically accurate language suitable for a security report. Avoid conversational filler, excessive jargon (unless standard for the context, e.g., specific DeFi terms if relevant), or overly "AI-like" phrasing. Aim for an "organic" feel as mentioned in the project goals.
+5.  **Accuracy is Paramount:** Prioritize accuracy based *only* on the provided information. Do not make assumptions or introduce external knowledge not present in the context, comment, or `@`-referenced materials. If information required by the template is missing, use clear placeholders (e.g., `[Severity Score]`, `[Link to Relevant Code Line]`, `[Detailed Scenario]`) or state that the information was not provided in the context.
+6.  **Output is a Draft:** Remember that your output is a *first draft*. It is expected to be reviewed, edited, potentially corrected, and thoroughly verified by the human user before submission. Do not present your output as infallible or complete.
+7.  **Focus on the Request:** Directly address the task of filling the template based on the comment. Do not add introductory or concluding remarks beyond the scope of the requested report content unless the template itself requires them.


### PR DESCRIPTION
Hi @0xEV_om,

This PR adds a `Rules/` directory containing two Custom Cursor Rules designed to enhance the report writing workflow described in the main README:

- `ReportDrafting_CursorRule.md`: Assists with drafting full reports using the templates.
- `PoC_Generation_CursorRule.md`: Provides focused help for generating Proofs of Concept.
- Add Codehawks template and `Report.md`
- Updated README.md to include the Codehawks Report

A `Rules/README.md` is included with instructions on how to add and use these rules in Cursor.

These rules help prime the AI for these specific tasks, aiming for more consistent and efficient draft generation. Hope this complements the existing templates well!
